### PR TITLE
Missing Chat Icon for Therapist

### DIFF
--- a/server/component/nav/NavModel.php
+++ b/server/component/nav/NavModel.php
@@ -220,7 +220,7 @@ class NavModel extends BaseModel
                 FROM users_groups ug
                 INNER JOIN acl_groups acl ON (acl.id_groups = ug.id_groups)
                 INNER JOIN pages p ON (acl.id_pages = p.id)
-                WHERE id_users = :uid AND keyword = 'chatSubject' AND acl_select = 1 AND ug.id_groups > 2
+                WHERE id_users = :uid AND keyword = 'chatSubject' AND acl_select = 1 AND ug.id_groups > 1
                 ORDER BY ug.id_groups ASC";
         return $this->db->query_db_first($sql, array(":uid"=>$_SESSION['id_user']));
     }


### PR DESCRIPTION
In GitLab by @moiri on Dec 7, 2020, 21:47

If a user only in the therapist group, the chat icon is not shown.

This change would fix this but was there a reason to exclude the therapist group?